### PR TITLE
fix: use v3 of BusArrival as v2 has been deprecated

### DIFF
--- a/ltapysg/api.py
+++ b/ltapysg/api.py
@@ -1,6 +1,6 @@
 from aiohttp import ClientSession, ClientConnectorError
 
-BASE_URL = "http://datamall2.mytransport.sg/ltaodataservice/"
+BASE_URL = "https://datamall2.mytransport.sg/ltaodataservice/"
 
 # Base async function to call api, receive response and handle errors.
 async def call(api_key, url):

--- a/ltapysg/bus.py
+++ b/ltapysg/bus.py
@@ -2,7 +2,7 @@ from .api import call
 
 # Retrieve arrival timings for all buses operating for specified bus stop. Each bus has 3 recurring timings.
 async def get_bus_arrival(api_key, bus_stop_code):
-    data = await call(api_key, "BusArrivalv2?BusStopCode=" + str(bus_stop_code))
+    data = await call(api_key, "v3/BusArrival?BusStopCode=" + str(bus_stop_code))
     return data["Services"]
 
 


### PR DESCRIPTION
Tested new API in postman, seems to have the same `Services` child entity. I've tested this code using a custom `ha-lta` python script and it seems to work fine.

https://datamall.lta.gov.sg/content/dam/datamall/datasets/LTA_DataMall_API_User_Guide.pdf